### PR TITLE
Allow workers to pull from queue on creation

### DIFF
--- a/lib/src/compute_api/compute_api.dart
+++ b/lib/src/compute_api/compute_api.dart
@@ -36,6 +36,7 @@ class ComputeAPI {
       if (_taskQueue.isNotEmpty) {
         _logger.log("Queue isn't empty, new worker picking task");
         final task = _taskQueue.removeFirst();
+        isRunning = true;
         worker.execute(task);
       }
     }

--- a/lib/src/compute_api/compute_api.dart
+++ b/lib/src/compute_api/compute_api.dart
@@ -33,6 +33,11 @@ class ComputeAPI {
       await worker.init(onResult: _onTaskFinished, onError: _onTaskFailed);
       _workers.add(worker);
       _logger.log('Worker $i has started');
+      if (_taskQueue.isNotEmpty) {
+        _logger.log("Queue isn't empty, new worker picking task");
+        final task = _taskQueue.removeFirst();
+        worker.execute(task);
+      }
     }
 
     isRunning = true;

--- a/lib/src/computer.dart
+++ b/lib/src/computer.dart
@@ -15,7 +15,7 @@ class Computer {
   /// Returns `true` if `Computer` turned on and `false` otherwise
   bool get isRunning => _computeDelegate.isRunning;
 
-  /// Turn on `Computer`, `workersCount` should not be more than 0, default is 2
+  /// Turn on `Computer`, `workersCount` should not be less than 1, default is 2
   /// `verbose` is false by default, enabling it leads to logging of every operation
   Future<void> turnOn({
     int workersCount = 2,

--- a/test/computer_test.dart
+++ b/test/computer_test.dart
@@ -1,5 +1,6 @@
 import 'package:computer/computer.dart';
 import 'package:computer/src/errors.dart';
+import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -97,6 +98,14 @@ void main() {
     );
 
     await computer.turnOff();
+  });
+
+  test('Add computes before workers have been created', () async {
+    final computer = Computer();
+    expect(Future.value(computer.compute<int, int>(fib, param: 20)), completion(equals(fib20())));
+    unawaited(computer.turnOn());
+
+    addTearDown(() async => await computer.turnOff());
   });
 
   test('Error method', () async {


### PR DESCRIPTION
Allow workers, after they are created, to pull from the task queue. 

1. Tasks created before turnOn is called will be executed
2. Tasks will be designated asap when you don't await for turnOn