### PR TITLE
Add optional param taskName for versbose logging

### DIFF
--- a/lib/src/compute_api/compute_api.dart
+++ b/lib/src/compute_api/compute_api.dart
@@ -56,15 +56,16 @@ class ComputeAPI {
   Future<R> compute<P, R>(
     Function fn, {
     P? param,
+    String? taskName = "Unknown",
   }) async {
-    _logger?.log('Started computation');
-
+    _logger?.log('Started computation for task ${taskName ?? ""}');
     final taskCapability = Capability();
     final taskCompleter = Completer<R>();
 
     final task = Task(
       task: fn,
       param: param,
+      name: taskName,
       capability: taskCapability,
     );
 
@@ -73,14 +74,14 @@ class ComputeAPI {
     final freeWorker = _findFreeWorker();
 
     if (freeWorker == null) {
-      _logger?.log('No free workers, add task to the queue');
+      _logger?.log('No free workers, add task ${taskName ?? ""} to the queue');
       if (_workers.length == 1) {
         _workers.single.execute(task);
       } else {
         _taskQueue.add(task);
       }
     } else {
-      _logger?.log('Found free worker, executing on it');
+      _logger?.log('Found free worker, executing ${taskName ?? ""} on it');
       freeWorker.execute(task);
     }
 
@@ -122,6 +123,7 @@ class ComputeAPI {
   void _onTaskFinished(TaskResult result, Worker worker) {
     final taskCompleter = _activeTaskCompleters.remove(result.capability)!;
     taskCompleter.complete(result.result);
+    _logger?.log('Finished task ${result.name ?? ""}');
 
     if (_taskQueue.isNotEmpty) {
       _logger?.log("Finished task on worker, queue isn't empty, pick task");

--- a/lib/src/compute_api/task.dart
+++ b/lib/src/compute_api/task.dart
@@ -3,22 +3,17 @@ import 'dart:isolate';
 class Task {
   final Function task;
   final dynamic param;
+  final String? name;
 
   final Capability capability;
 
-  Task({
-    required this.task,
-    required this.capability,
-    this.param,
-  });
+  Task({required this.task, required this.capability, this.param, this.name});
 }
 
 class TaskResult {
   final dynamic result;
   final Capability capability;
+  final String? name;
 
-  TaskResult({
-    required this.result,
-    required this.capability,
-  });
+  TaskResult({required this.result, required this.capability, this.name});
 }

--- a/lib/src/compute_api/worker.dart
+++ b/lib/src/compute_api/worker.dart
@@ -93,6 +93,7 @@ Future<void> isolateEntryPoint(IsolateInitParams params) async {
       final result = TaskResult(
         result: computationResult,
         capability: task.capability,
+        name: task.name,
       );
       sendPort.send(result);
     } catch (error) {

--- a/lib/src/computer.dart
+++ b/lib/src/computer.dart
@@ -31,11 +31,13 @@ class Computer {
 
   /// Executes function `fn` with passed `param`. Takes only top-level functions and static methods.
   /// `P` is `param` type, `R` is function return type
+  /// `taskName` is a identifier for the task that's only used during logging
   Future<R> compute<P, R>(
     Function fn, {
     P? param,
+    String? taskName,
   }) async {
-    return _computeDelegate.compute<P, R>(fn, param: param);
+    return _computeDelegate.compute<P, R>(fn, param: param, taskName: taskName);
   }
 
   /// Turn off `Computer`


### PR DESCRIPTION

In case of Shared computer, without any task identifier/name, it's difficult to identify what tasks are being executed inside the computer/Isolate.
This change adds an optional parameter `taskName`, which is only used during logging.